### PR TITLE
Add automatic CI versioning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ deploy:
     tags: true
 env:
   global:
+  - OWNER_NAME=BrightspaceUI
   - REPO_NAME=link
   - SAUCE_USERNAME: Desire2Learn
   - secure: OiBrrLVxknJO2DGUuxz9Hkg98Zcot7HklpraLHdejsqfqEkEs8NQxr+YVFTNYSNhnzI4nwumhvGYcnlOcdA2+XQlTrJuwPI8eH9dDFEaQs3Qlo92yNjnoLDF93XbZihp4qYtOxBiPuW1rsIZ8bTTxkSbJ2Cxc3wEJWuTx01m2YY=

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,20 @@ addons:
 before_install:
 - export JAVA_HOME=/usr/lib/jvm/java-8-oracle
 - export PATH=$JAVA_HOME/bin:$PATH
+- |
+  if [ "$TRAVIS_BRANCH" == "master" ] && [ $TRAVIS_PULL_REQUEST == false ]; then
+    echo "Not a Pull Request and on branch master so bumping version";
+    frauci-update-version;
+    export TRAVIS_TAG=$(frauci-get-version)
+  fi
+deploy:
+  provider: releases
+  api_key: "$GITHUB_RELEASE_TOKEN"
+  on:
+    tags: true
 env:
   global:
+  - REPO_NAME=link
   - SAUCE_USERNAME: Desire2Learn
   - secure: OiBrrLVxknJO2DGUuxz9Hkg98Zcot7HklpraLHdejsqfqEkEs8NQxr+YVFTNYSNhnzI4nwumhvGYcnlOcdA2+XQlTrJuwPI8eH9dDFEaQs3Qlo92yNjnoLDF93XbZihp4qYtOxBiPuW1rsIZ8bTTxkSbJ2Cxc3wEJWuTx01m2YY=
+  - secure: VQG/4O+tDMa5k0C051jllUxYWM5fw7MCn1gNhP8qZjIcFGVQ9miDYXmr+NGpsP1CfTCKKkYxuE0aVsPi4IG0+dsNIhOfyEb+LT3o4F18L8CxPdRu62rfaR0a2/xudZd7TABmZJ4oc3DbqmqFRBPF0HrPPP6eZG8wQFSbs8IXLAU=

--- a/README.md
+++ b/README.md
@@ -163,3 +163,12 @@ The output of the Galen tests can be dumped using the command `npm run galen:loc
 [bower-image]: https://badge.fury.io/bo/d2l-link.svg
 [ci-image]: https://travis-ci.org/BrightspaceUI/link.svg?branch=master
 [ci-url]: https://travis-ci.org/BrightspaceUI/link
+
+## Versioning
+
+Commits and PR merges to master will automatically do a minor version bump which will:
+* Update the version in `package.json`
+* Add a tag matching the new version
+* Create a github release matching the new version
+
+By using either **[increment major]** or **[increment patch]** notation inside your merge message, you can overwrite the default version upgrade of minor to the position of your choice.

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "sauceconnect-runner": "git+https://github.com/Brightspace/sauceconnect-runner.git#v0.3.0",
     "wct-browser-legacy": "^1.0.1"
   },
-  "version": "5.0.2",
+  "version": "5.0.3",
   "resolutions": {
     "inherits": "2.0.3",
     "samsam": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "sauceconnect-runner": "git+https://github.com/Brightspace/sauceconnect-runner.git#v0.3.0",
     "wct-browser-legacy": "^1.0.1"
   },
-  "version": "5.0.3",
+  "version": "5.0.4",
   "resolutions": {
     "inherits": "2.0.3",
     "samsam": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "sauceconnect-runner": "git+https://github.com/Brightspace/sauceconnect-runner.git#v0.3.0",
     "wct-browser-legacy": "^1.0.1"
   },
-  "version": "",
+  "version": "5.0.1",
   "resolutions": {
     "inherits": "2.0.3",
     "samsam": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "eslint": "^4.15.0",
     "eslint-config-brightspace": "^0.4.0",
     "eslint-plugin-html": "^4.0.1",
+    "frau-ci": "^1.33.2",
     "galenframework": "^2.3.4",
     "node-sass": "^4.5.3",
     "polymer-cli": "^1.9.1",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "sauceconnect-runner": "git+https://github.com/Brightspace/sauceconnect-runner.git#v0.3.0",
     "wct-browser-legacy": "^1.0.1"
   },
-  "version": "5.0.1",
+  "version": "5.0.2",
   "resolutions": {
     "inherits": "2.0.3",
     "samsam": "1.1.3",


### PR DESCRIPTION
Updates travis.yml to use frauci-update-version to bump package.json version and tag commit on each commit/pr merge to master. Use travis releases provider to create a new github release matching tag.