### PR TITLE
Add attribute aria-label to d2l-link

### DIFF
--- a/d2l-link.js
+++ b/d2l-link.js
@@ -55,8 +55,7 @@ Polymer({
 		 * A string to be used as the accessible label, which overrides text content.
 		 */
 		ariaLabel: {
-			type: String,
-			reflectToAttribute: true
+			type: String
 		},
 
 		/**

--- a/d2l-link.js
+++ b/d2l-link.js
@@ -35,9 +35,9 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-link">
 				@apply --d2l-link-hover;
 			}
 		</style>
-		<a class="d2l-link-elem d2l-focusable" download$="[[download]]" href$="[[href]]" hreflang="[[hreflang]]" rel="[[rel]]" target="[[target]]" type="[[type]]"><slot></slot></a>
+		<a class="d2l-link-elem d2l-focusable" aria-label$="[[ariaLabel]]" download$="[[download]]" href$="[[href]]" hreflang="[[hreflang]]" rel="[[rel]]" target="[[target]]" type="[[type]]"><slot></slot></a>
 	</template>
-	
+
 </dom-module>`;
 
 document.head.appendChild($_documentContainer.content);
@@ -50,6 +50,14 @@ Polymer({
 	],
 
 	properties: {
+
+		/**
+		 * A string to be used as the accessible label, which overrides text content.
+		 */
+		ariaLabel: {
+			type: String,
+			reflectToAttribute: true
+		},
 
 		/**
 		 * When this attribute is present, a bolder style is applied.

--- a/test/d2l-link.html
+++ b/test/d2l-link.html
@@ -84,7 +84,7 @@ describe('d2l-link', () => {
 				{name: 'rel', value: 'this that', valueAlt: 'other thing'},
 				{name: 'target', value: '_blank', valueAlt: 'foo'},
 				{name: 'type', value: 'image/jpeg', valueAlt: 'text/html'},
-				{name: 'aria-label', internalName: 'ariaLabel', value: 'My Aria Label', valueAlt: 'Screen Reader Text'}
+				{name: 'aria-label', internalName: 'ariaLabel', ignoreReflectToAttribute: true, value: 'My Aria Label', valueAlt: 'Screen Reader Text'}
 			].forEach((attr) => {
 
 				const internalName = attr.internalName || attr.name;
@@ -97,7 +97,10 @@ describe('d2l-link', () => {
 
 				it(`should reflect "${attr.name}" property change to attribute and anchor`, () => {
 					elem[internalName] = attr.valueAlt;
-					expect(elem.getAttribute(attr.name)).to.equal(attr.valueAlt);
+
+					if (!attr.ignoreReflectToAttribute) {
+						expect(elem.getAttribute(attr.name)).to.equal(attr.valueAlt);
+					}
 					expect(elem.$$('a').getAttribute(attr.name)).to.equal(attr.valueAlt);
 				});
 

--- a/test/d2l-link.html
+++ b/test/d2l-link.html
@@ -19,7 +19,8 @@
 		<test-fixture id="attributes">
 			<template>
 				<d2l-link
-					 download
+					aria-label='My Aria Label'
+					download
 					href="https://www.d2l.com"
 					hreflang="en"
 					main
@@ -82,30 +83,33 @@ describe('d2l-link', () => {
 				{name: 'hreflang', value: 'en', valueAlt: 'fr'},
 				{name: 'rel', value: 'this that', valueAlt: 'other thing'},
 				{name: 'target', value: '_blank', valueAlt: 'foo'},
-				{name: 'type', value: 'image/jpeg', valueAlt: 'text/html'}
+				{name: 'type', value: 'image/jpeg', valueAlt: 'text/html'},
+				{name: 'aria-label', internalName: 'ariaLabel', value: 'My Aria Label', valueAlt: 'Screen Reader Text'}
 			].forEach((attr) => {
 
+				const internalName = attr.internalName || attr.name;
+
 				it(`should default "${attr.name}" to undefined`, () => {
-					expect(elem[attr.name]).to.be.undefined;
+					expect(elem[internalName]).to.be.undefined;
 					expect(elem.hasAttribute(attr.name)).to.be.false;
 					expect(elem.$$('a').hasAttribute(attr.name)).to.be.false;
 				});
 
 				it(`should reflect "${attr.name}" property change to attribute and anchor`, () => {
-					elem[attr.name] = attr.valueAlt;
+					elem[internalName] = attr.valueAlt;
 					expect(elem.getAttribute(attr.name)).to.equal(attr.valueAlt);
 					expect(elem.$$('a').getAttribute(attr.name)).to.equal(attr.valueAlt);
 				});
 
 				it(`should reflect "${attr.name}" attribute change to property and anchor`, () => {
 					elem.setAttribute(attr.name, attr.valueAlt);
-					expect(elem[attr.name]).to.equal(attr.valueAlt);
+					expect(elem[internalName]).to.equal(attr.valueAlt);
 					expect(elem.$$('a').getAttribute(attr.name)).to.equal(attr.valueAlt);
 				});
 
 				it(`should have initial value "${attr.name}" of "${attr.value}"`, () => {
 					elem = fixture('attributes');
-					expect(elem[attr.name]).to.equal(attr.value);
+					expect(elem[internalName]).to.equal(attr.value);
 					expect(elem.getAttribute(attr.name)).to.be.equal(attr.value);
 					expect(elem.$$('a').getAttribute(attr.name)).to.equal(attr.value);
 				});


### PR DESCRIPTION
* Adding aria-label support to d2l-link
* Adding because I have a use-case where I would like the screen-reader to read something different than what is displayed on the screen